### PR TITLE
Add client multiple api keys management

### DIFF
--- a/iugu.gemspec
+++ b/iugu.gemspec
@@ -19,10 +19,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-nav'
 end

--- a/lib/iugu.rb
+++ b/lib/iugu.rb
@@ -18,6 +18,7 @@ require_relative 'iugu/invoice'
 require_relative 'iugu/subscription'
 require_relative 'iugu/charge'
 require_relative 'iugu/plan'
+require_relative 'iugu/client'
 
 module Iugu
   class AuthenticationException < StandardError

--- a/lib/iugu/api_create.rb
+++ b/lib/iugu/api_create.rb
@@ -1,21 +1,12 @@
 module Iugu
   module APICreate
-    module ClassMethods
-      def create(attributes = {})
-        Iugu::Factory.create_from_response(self.object_type,
-                                           APIRequest.request('POST',
-                                                              self.url(attributes),
-                                                              attributes))
-      rescue Iugu::RequestWithErrors => ex
-        obj = self.new
-        obj.set_attributes attributes, true
-        obj.errors = ex.errors
-        obj
-      end
-    end
-
-    def self.included(base)
-      base.extend(ClassMethods)
+    def create(attributes = {})
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST', self.class.url(attributes), attributes))
+    rescue Iugu::RequestWithErrors => ex
+      obj = self.class.new
+      obj.set_attributes attributes, true
+      obj.errors = ex.errors
+      obj
     end
   end
 end

--- a/lib/iugu/api_delete.rb
+++ b/lib/iugu/api_delete.rb
@@ -1,7 +1,7 @@
 module Iugu
   module APIDelete
     def delete
-      APIRequest.request('DELETE', self.class.url(self.attributes))
+      APIRequest.request(self, 'DELETE', self.class.url(self.attributes))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/api_fetch.rb
+++ b/lib/iugu/api_fetch.rb
@@ -1,9 +1,7 @@
 module Iugu
   module APIFetch
     def refresh
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('GET',
-                                                                 self.class.url(self.id)))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET', self.class.url(self.id)))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -11,16 +9,8 @@ module Iugu
       false
     end
 
-    module ClassMethods
-      def fetch(options = nil)
-        Iugu::Factory.create_from_response(self.object_type,
-                                           APIRequest.request('GET',
-                                                              self.url(options)))
-      end
-    end
-
-    def self.included(base)
-      base.extend(ClassMethods)
+    def fetch(options = {})
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET', self.class.url(options)))
     end
   end
 end

--- a/lib/iugu/api_save.rb
+++ b/lib/iugu/api_save.rb
@@ -2,10 +2,8 @@ module Iugu
   module APISave
     def save
       method = is_new? ? 'POST' : 'PUT'
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request(method,
-                                                                 self.class.url(self.attributes),
-                                                                 modified_attributes))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, method, self.class.url(self.attributes),
+                                                                       modified_attributes))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/api_search.rb
+++ b/lib/iugu/api_search.rb
@@ -1,13 +1,7 @@
 module Iugu
   module APICreate
-    module ClassMethods
-      def search(options = {})
-        Iugu::Factory.create_from_response self.object_type, APIRequest.request("GET", self.url(options), options)
-      end
-    end
-
-    def self.included(base)
-      base.extend(ClassMethods)
+    def search(options = {})
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, "GET", self.class.url(options), options))
     end
   end
 end

--- a/lib/iugu/charge.rb
+++ b/lib/iugu/charge.rb
@@ -8,7 +8,7 @@ module Iugu
 
     def invoice
       return false unless @attributes['invoice_id']
-      Invoice.fetch @attributes['invoice_id']
+      Invoice.new(options: self.options).fetch(@attributes['invoice_id'])
     end
   end
 end

--- a/lib/iugu/client.rb
+++ b/lib/iugu/client.rb
@@ -1,0 +1,42 @@
+
+module Iugu
+  class Client
+    def initialize(api_key:)
+      @api_key = api_key
+    end
+
+    def charge
+      Iugu::Charge.new(options)
+    end
+
+    def customer
+      Iugu::Customer.new(options)
+    end
+
+    def invoice
+      Iugu::Invoice.new(options)
+    end
+
+    def payment_method
+      Iugu::PaymentMethod.new(options)
+    end
+
+    def payment_token
+      Iugu::PaymentToken.new(options)
+    end
+
+    def subscription
+      Iugu::Subscription.new(options)
+    end
+
+    def plan
+      Iugu::Plan.new(options)
+    end
+
+    private
+
+    def options
+      { options: { api_key: @api_key } }
+    end
+  end
+end

--- a/lib/iugu/client.rb
+++ b/lib/iugu/client.rb
@@ -1,7 +1,7 @@
 
 module Iugu
   class Client
-    def initialize(api_key:)
+    def initialize(api_key: Iugu.api_key || Iugu.auth_from_env)
       @api_key = api_key
     end
 

--- a/lib/iugu/customer.rb
+++ b/lib/iugu/customer.rb
@@ -6,16 +6,16 @@ module Iugu
     include Iugu::APIDelete
 
     def payment_methods
-      APIChildResource.new({ customer_id: self.id }, Iugu::PaymentMethod)
+      APIChildResource.new({ customer_id: self.id }, Iugu::PaymentMethod.new(options: self.options))
     end
 
     def invoices
-      APIChildResource.new({ customer_id: self.id }, Iugu::Invoice)
+      APIChildResource.new({ customer_id: self.id }, Iugu::Invoice.new(options: self.options))
     end
 
     def default_payment_method
       return false unless @attributes['default_payment_method_id']
-      PaymentMethod.fetch({ id: @attributes['default_payment_method_id'], customer_id: self.id })
+      PaymentMethod.new(options: self.options).fetch({ id: @attributes['default_payment_method_id'], customer_id: self.id })
     end
   end
 end

--- a/lib/iugu/factory.rb
+++ b/lib/iugu/factory.rb
@@ -1,6 +1,9 @@
 module Iugu
   class Factory
-    def self.create_from_response(object_type, response, errors = nil)
+    def self.create_from_response(object, response, errors = nil)
+      object_type = object.class.object_type
+      options = object.options
+
       if response.nil?
         obj = Iugu.const_get(Iugu::Utils.camelize(object_type)).new
         obj.errors = errors if errors
@@ -8,17 +11,17 @@ module Iugu
       elsif response.is_a?(Array)
         results = []
         response.each do |i|
-          results.push Iugu.const_get(Iugu::Utils.camelize(object_type)).new i
+          results.push Iugu.const_get(Iugu::Utils.camelize(object_type)).new(attributes: i, options: options)
         end
         Iugu::SearchResult.new results, results.count
       elsif response['items'] && response['totalItems']
         results = []
         response['items'].each do |v|
-          results.push self.create_from_response(object_type, v)
+          results.push self.create_from_response(object, v)
         end
         Iugu::SearchResult.new results, response['totalItems']
       else
-        Iugu.const_get(Iugu::Utils.camelize(object_type)).new response
+        Iugu.const_get(Iugu::Utils.camelize(object_type)).new(attributes: response, options: options)
       end
     end
   end

--- a/lib/iugu/invoice.rb
+++ b/lib/iugu/invoice.rb
@@ -7,13 +7,11 @@ module Iugu
 
     def customer
       return false unless @attributes['customer_id']
-      Customer.fetch @attributes['customer_id']
+      Customer.new(options: self.options).fetch(@attributes['customer_id'])
     end
 
     def cancel
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/cancel"))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'PUT', "#{self.class.url(self.id)}/cancel"))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -22,9 +20,7 @@ module Iugu
     end
 
     def refund
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/refund"))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST', "#{self.class.url(self.id)}/refund"))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -33,10 +29,7 @@ module Iugu
     end
 
     def duplicate(attributes = {})
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/duplicate",
-                                                                 attributes ))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST', "#{self.class.url(self.id)}/duplicate", attributes))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/object.rb
+++ b/lib/iugu/object.rb
@@ -3,12 +3,13 @@ require 'set'
 module Iugu
   class Object
 
-    attr_accessor :errors
+    attr_accessor :errors, :options
 
     undef :id if method_defined?(:id)
 
-    def initialize(attributes = {})
+    def initialize(attributes: {}, options: {})
       @unsaved_attributes = Set.new
+      @options = options
       set_attributes attributes
     end
 
@@ -53,6 +54,13 @@ module Iugu
         add_accessor(k)
       end
       @unsaved_attributes = @attributes.keys.to_set if unsaved
+    end
+
+    def api_key
+      @api_key ||=
+        begin
+          options[:api_key] || Iugu.api_key || Utils.auth_from_env
+        end
     end
 
     protected

--- a/lib/iugu/plan.rb
+++ b/lib/iugu/plan.rb
@@ -5,10 +5,8 @@ module Iugu
     include Iugu::APISave
     include Iugu::APIDelete
 
-    def self.fetch_by_identifier(identifier)
-      Iugu::Factory.create_from_response(object_type,
-                                         APIRequest.request('GET',
-                                                            "#{url}/identifier/#{identifier}"))
+    def fetch_by_identifier(identifier)
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET', "#{url}/identifier/#{identifier}"))
     end
   end
 end

--- a/lib/iugu/plan.rb
+++ b/lib/iugu/plan.rb
@@ -6,7 +6,7 @@ module Iugu
     include Iugu::APIDelete
 
     def fetch_by_identifier(identifier)
-      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET', "#{url}/identifier/#{identifier}"))
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET', "#{self.class.url}/identifier/#{identifier}"))
     end
   end
 end

--- a/lib/iugu/search_result.rb
+++ b/lib/iugu/search_result.rb
@@ -12,5 +12,7 @@ module Iugu
     def results
       @results
     end
+
+    alias_method :count, :total
   end
 end

--- a/lib/iugu/subscription.rb
+++ b/lib/iugu/subscription.rb
@@ -6,10 +6,9 @@ module Iugu
     include Iugu::APIDelete
 
     def add_credits(quantity)
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/add_credits",
-                                                                 { quantity: quantity }))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'PUT',
+                                                                       "#{self.class.url(self.id)}/add_credits",
+                                                                       { quantity: quantity }))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -18,10 +17,9 @@ module Iugu
     end
 
     def remove_credits(quantity)
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/remove_credits",
-                                                                 { quantity: quantity }))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'PUT',
+                                                                       "#{self.class.url(self.id)}/remove_credits",
+                                                                       { quantity: quantity }))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -30,9 +28,8 @@ module Iugu
     end
 
     def suspend
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/suspend"))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST',
+                                                                       "#{self.class.url(self.id)}/suspend"))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -41,9 +38,8 @@ module Iugu
     end
 
     def activate
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/activate"))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST',
+                                                                       "#{self.class.url(self.id)}/activate"))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -53,10 +49,9 @@ module Iugu
 
     def change_plan(plan_identifier, options = {})
       options.merge!({ plan_identifier: plan_identifier })
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/change_plan",
-                                                                 options))
+      copy Iugu::Factory.create_from_response(self, APIRequest.request(self, 'POST',
+                                                                       "#{self.class.url(self.id)}/change_plan",
+                                                                       options))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -66,15 +61,14 @@ module Iugu
 
     def change_plan_simulation(plan_identifier, options = {})
       options.merge!({ plan_identifier: plan_identifier })
-      Iugu::Factory.create_from_response(self.class.object_type,
-                                         APIRequest.request('GET',
-                                                            "#{self.class.url(self.id)}/change_plan_simulation",
-                                                            options))
+      Iugu::Factory.create_from_response(self, APIRequest.request(self, 'GET',
+                                                                  "#{self.class.url(self.id)}/change_plan_simulation",
+                                                                  options))
     end
 
     def customer
       return false unless @attributes['customer_id']
-      Customer.fetch @attributes['customer_id']
+      Customer.new(options: self.options).fetch(@attributes['customer_id'])
     end
   end
 end

--- a/spec/charge_spec.rb
+++ b/spec/charge_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Iugu::Charge do
+  subject(:client) { Iugu::Client.new }
+
   describe '.create' do
     it 'should create a charge', :vcr do
-      charge = Iugu::Charge.create(method: 'bank_slip',
+      charge = client.charge.create(method: 'bank_slip',
                                    payer: { name: 'Awesome Customer',
                                             cpf_cnpj: '15111975000164',
                                             address: { zip_code: '29190560', number: '100'} },
@@ -20,7 +22,7 @@ describe Iugu::Charge do
     end
 
     it 'should create a charge with credit card', :vcr do
-      token = Iugu::PaymentToken.create(account_id: '842C5942D8E34372A8E554A1BC959086',
+      token = client.payment_token.create(account_id: '842C5942D8E34372A8E554A1BC959086',
                                         method: 'credit_card',
                                         test: 'true',
                                         data: {
@@ -33,7 +35,7 @@ describe Iugu::Charge do
                                         })
 
 
-      charge = Iugu::Charge.create(token: token.id,
+      charge = client.charge.create(token: token.id,
                                    payer: { name: 'Awesome Customer',
                                             cpf_cnpj: '15111975000164',
                                             address: { zip_code: '29190560', number: '100'} },
@@ -53,7 +55,7 @@ describe Iugu::Charge do
     end
 
     it 'should create a charge with credit card with installments', :vcr do
-      token = Iugu::PaymentToken.create(account_id: 'F17761200EC74469823D469BF2B211AC',
+      token = client.payment_token.create(account_id: 'F17761200EC74469823D469BF2B211AC',
                                         method: 'credit_card',
                                         test: 'true',
                                         data: {
@@ -66,7 +68,7 @@ describe Iugu::Charge do
                                         })
 
 
-      charge = Iugu::Charge.create(token: token.id,
+      charge = client.charge.create(token: token.id,
                                    payer: { name: 'Awesome Customer',
                                             cpf_cnpj: '15111975000164',
                                             address: { zip_code: '29190560', number: '100'} },
@@ -77,7 +79,7 @@ describe Iugu::Charge do
                                    months: 3, # 3 installments
                                    email: 'example@example.example')
 
-      invoice = Iugu::Invoice.fetch(id: charge.invoice_id)
+      invoice = client.invoice.fetch(id: charge.invoice_id)
 
       expect(charge.success).to be_truthy
       expect(invoice.status).to eq('paid')

--- a/spec/customer_spec.rb
+++ b/spec/customer_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Iugu::Customer do
+  subject(:client) { Iugu::Client.new }
+
   describe '.create' do
     it 'should create a customer with just the email and name', :vcr do
-      customer = Iugu::Customer.create(email: 'john.snow@greatwall.com',
+      customer = client.customer.create(email: 'john.snow@greatwall.com',
                                        name: 'John Snow',
                                        notes: 'knows nothing')
 
@@ -14,7 +16,7 @@ describe Iugu::Customer do
     end
 
     it 'should create a customer with CPF', :vcr do
-      customer = Iugu::Customer.create(email: 'john.snow@greatwall.com',
+      customer = client.customer.create(email: 'john.snow@greatwall.com',
                                        name: 'John Snow',
                                        cpf_cnpj: '648.144.103-01')
 
@@ -23,7 +25,7 @@ describe Iugu::Customer do
     end
 
     it 'should create a customer with CPNJ', :vcr do
-      customer = Iugu::Customer.create(email: 'john.snow@greatwall.com',
+      customer = client.customer.create(email: 'john.snow@greatwall.com',
                                        name: 'John Snow',
                                        cpf_cnpj: '57.202.023/6256-27')
 
@@ -32,7 +34,7 @@ describe Iugu::Customer do
     end
 
     it 'should create a customer with full address', :vcr do
-      customer = Iugu::Customer.create(email: 'john.snow@greatwall.com',
+      customer = client.customer.create(email: 'john.snow@greatwall.com',
                                        name: 'John Snow',
                                        cpf_cnpj: '648.144.103-01',
                                        cc_emails: 'heisenberg@lospolloshermanos.com',
@@ -55,20 +57,20 @@ describe Iugu::Customer do
     end
 
     it 'should raise error when the email is empty', :vcr do
-      customer = Iugu::Customer.create
+      customer = client.customer.create
       expect(customer.errors['email']).to_not be_nil
     end
   end
 
   describe '.fetch' do
     it 'should return customers', :vcr do
-      customers = Iugu::Customer.fetch
+      customers = client.customer.fetch
 
       expect(customers.total).to eq(15)
     end
 
     it 'should return the customer', :vcr do
-      customer = Iugu::Customer.fetch(id: '2D3309067D0047B7AD55F38EBA0BA406')
+      customer = client.customer.fetch(id: '2D3309067D0047B7AD55F38EBA0BA406')
 
       expect(customer.email).to eq('john.snow@greatwall.com')
       expect(customer.name).to eq('John Snow')
@@ -77,7 +79,7 @@ describe Iugu::Customer do
 
   describe '.save' do
     it 'should save the customer', :vcr do
-      customer = Iugu::Customer.create(email: 'john.snow@greatwall.com',
+      customer = client.customer.create(email: 'john.snow@greatwall.com',
                                        name: 'John Snow',
                                        cpf_cnpj: '648.144.103-01',
                                        cc_emails: 'heisenberg@lospolloshermanos.com',
@@ -100,7 +102,7 @@ describe Iugu::Customer do
 
       customer.save
 
-      new_customer = Iugu::Customer.fetch(id: customer.id)
+      new_customer = client.customer.fetch(id: customer.id)
 
       expect(new_customer.zip_code).to eq('13058676')
       expect(new_customer.number).to eq('+9000')
@@ -112,7 +114,7 @@ describe Iugu::Customer do
 
   describe '.delete' do
     it 'should save the customer', :vcr do
-      customer = Iugu::Customer.create(email: 'john.snow@greatwall.com',
+      customer = client.customer.create(email: 'john.snow@greatwall.com',
                                        name: 'John Snow',
                                        cpf_cnpj: '648.144.103-01',
                                        cc_emails: 'heisenberg@lospolloshermanos.com',
@@ -125,7 +127,7 @@ describe Iugu::Customer do
                                        complement: '123C')
       customer.delete
 
-      expect { Iugu::Customer.fetch(id: customer.id) }.to raise_error(Iugu::ObjectNotFound)
+      expect { client.customer.fetch(id: customer.id) }.to raise_error(Iugu::ObjectNotFound)
     end
   end
 end

--- a/spec/invoice_spec.rb
+++ b/spec/invoice_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Iugu::Invoice do
+  subject(:client) { Iugu::Client.new }
+
   describe '.create' do
     it 'should create an invoice for credit card payment', :vcr do
-      invoice = Iugu::Invoice.create(email: 'homer@simpsom.com',
+      invoice = client.invoice.create(email: 'homer@simpsom.com',
                                      due_date: '2017-11-30',
                                      items: [{ price_cents: 100, description: 'Rosquinha', quantity: 99 }],
                                      payable_with: 'credit_card')
@@ -19,13 +21,13 @@ describe Iugu::Invoice do
 
   describe '.fetch' do
     it 'should return invoices', :vcr do
-      invoices = Iugu::Invoice.fetch
+      invoices = client.invoice.fetch
 
       expect(invoices.total).to eq(5)
     end
 
     it 'should return invoice', :vcr do
-      invoice = Iugu::Invoice.fetch(id: '3F14349B01264947A3765A79B1DEA1B4')
+      invoice = client.invoice.fetch(id: '3F14349B01264947A3765A79B1DEA1B4')
 
       expect(invoice.email).to eq('homer@simpsom.com')
       expect(invoice.due_date).to eq('2017-11-30')

--- a/spec/payment_token_spec.rb
+++ b/spec/payment_token_spec.rb
@@ -2,8 +2,10 @@ require 'spec_helper'
 
 describe Iugu::PaymentToken do
   describe '.create' do
+    subject(:client) { Iugu::Client.new }
+
     it 'should create a payment token', :vcr do
-      token = Iugu::PaymentToken.create(account_id: '842C5942D8E34372A8E554A1BC959086',
+      token = client.payment_token.create(account_id: '842C5942D8E34372A8E554A1BC959086',
                                         method: 'credit_card',
                                         test: 'true',
                                         data: {

--- a/spec/plan_spec.rb
+++ b/spec/plan_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Iugu::Plan do
+  subject(:client) { Iugu::Client.new }
+
   describe '.create' do
     it 'should create a plan', :vcr do
-      plan = Iugu::Plan.create(name: 'Medium',
+      plan = client.plan.create(name: 'Medium',
                                identifier: 'medium',
                                interval: '1',
                                interval_type: 'months',
@@ -20,13 +22,13 @@ describe Iugu::Plan do
 
   describe '.fetch' do
     it 'should return plans', :vcr do
-      plan = Iugu::Plan.fetch
+      plan = client.plan.fetch
 
       expect(plan.total).to eq(2)
     end
 
     it 'should return the plan', :vcr do
-      plan = Iugu::Plan.fetch_by_identifier('medium')
+      plan = client.plan.fetch_by_identifier('medium')
 
       expect(plan.name).to eq('Medium')
       expect(plan.identifier).to eq('medium')
@@ -38,14 +40,14 @@ describe Iugu::Plan do
 
   describe '.save' do
     it 'should save the plan', :vcr do
-      plan = Iugu::Plan.fetch_by_identifier('medium')
+      plan = client.plan.fetch_by_identifier('medium')
 
       plan.name = 'Super Medium'
       plan.value_cents = '12000'
 
       plan.save
 
-      saved_plan = Iugu::Plan.fetch(id: plan.id)
+      saved_plan = client.plan.fetch(id: plan.id)
 
       expect(saved_plan.name).to eq('Super Medium')
       expect(saved_plan.prices.first['value_cents']).to eq(12000)
@@ -54,11 +56,11 @@ describe Iugu::Plan do
 
   describe '.delete' do
     it 'should delete the plan', :vcr do
-      plan = Iugu::Plan.fetch_by_identifier('medium')
+      plan = client.plan.fetch_by_identifier('medium')
 
       plan.delete
 
-      expect { Iugu::Plan.fetch(id: plan.id) }.to raise_error(Iugu::ObjectNotFound)
+      expect { client.plan.fetch(id: plan.id) }.to raise_error(Iugu::ObjectNotFound)
     end
   end
 end

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Iugu::Subscription do
+  subject(:client) { Iugu::Client.new }
+
   describe '.create' do
     it 'should create a subscription', :vcr do
-      subscription = Iugu::Subscription.create(plan_identifier: 'basic',
+      subscription = client.subscription.create(plan_identifier: 'basic',
                                                customer_id: '524AB141252E44D3B2D006D8845DB261',
                                                credits_based: false,
                                                expires_at: Date.new(2018, 8, 8))
@@ -13,7 +15,7 @@ describe Iugu::Subscription do
     end
 
     it 'should create a subscription and an invoice when it is about to expire', :vcr do
-      subscription = Iugu::Subscription.create(plan_identifier: 'basic',
+      subscription = client.subscription.create(plan_identifier: 'basic',
                                                customer_id: '8941A38AB8BF4BBAA595C0E03F379C9C',
                                                expires_at: Date.new(2018, 1, 4))
 
@@ -21,7 +23,7 @@ describe Iugu::Subscription do
     end
 
     it 'should create a subscription but not an invoice when it will expire 5 five days from now', :vcr do
-      subscription = Iugu::Subscription.create(plan_identifier: 'basic',
+      subscription = client.subscription.create(plan_identifier: 'basic',
                                                payable_with: 'credit_card',
                                                customer_id: '8941A38AB8BF4BBAA595C0E03F379C9C',
                                                expires_at: Date.new(2018, 1, 10))
@@ -32,7 +34,7 @@ describe Iugu::Subscription do
 
   describe '.fetch' do
     it 'should return subscriptions', :vcr do
-      subscriptions = Iugu::Subscription.fetch
+      subscriptions = client.subscription.fetch
 
       expect(subscriptions.total).to eq(2)
     end
@@ -40,12 +42,12 @@ describe Iugu::Subscription do
 
   describe '.save' do
     it 'should save the subscription', :vcr do
-      subscription = Iugu::Subscription.fetch(id: '1CBD18FA1E4B47C891EFD82EF4321BC4')
+      subscription = client.subscription.fetch(id: '1CBD18FA1E4B47C891EFD82EF4321BC4')
       subscription.plan_identifier = 'medium'
 
       subscription.save
 
-      saved_subscription = Iugu::Subscription.fetch(id: '1CBD18FA1E4B47C891EFD82EF4321BC4')
+      saved_subscription = client.subscription.fetch(id: '1CBD18FA1E4B47C891EFD82EF4321BC4')
 
       expect(saved_subscription.plan_identifier).to eq('medium')
     end
@@ -53,11 +55,11 @@ describe Iugu::Subscription do
 
   describe '.delete' do
     it 'should delete the subscription', :vcr do
-      subscription = Iugu::Subscription.fetch(id: 'C09161223BE1467E9DC4F4DFCC5687DC')
+      subscription = client.subscription.fetch(id: 'C09161223BE1467E9DC4F4DFCC5687DC')
 
       subscription.delete
 
-      expect { Iugu::Subscription.fetch(id: subscription.id) }.to raise_error(Iugu::ObjectNotFound)
+      expect { client.subscription.fetch(id: subscription.id) }.to raise_error(Iugu::ObjectNotFound)
     end
   end
 end


### PR DESCRIPTION
This commit will apply a massive change by adding the possibility
to add more than one api_token to handle more than one account.
So if you have multiple accounts using the Gateway, with this changing
you will possible to handle it easily by configuring the client as
follows:

```
client = Iugu::Client.new(api_token: xxx)
client.invoice.fetch
client.customer.fetch
...
```

This changing is heavily inpisred by The Twitter Ruby Gem