### PR TITLE
Add api key as option to manage multiple accounts

### DIFF
--- a/iugu.gemspec
+++ b/iugu.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-nav'
 end

--- a/iugu.gemspec
+++ b/iugu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'byebug'

--- a/lib/iugu/api_child_resource.rb
+++ b/lib/iugu/api_child_resource.rb
@@ -1,23 +1,21 @@
 module Iugu
   class APIChildResource
-    @parent_keys = {}
-    @fabricator = nil
-
-    def initialize(parent_keys = {}, fabricator)
+    def initialize(parent_keys = {}, fabricator = nil, options = {})
       @parent_keys = parent_keys
       @fabricator = fabricator
+      @options = options
     end
 
-    def create(attributes = {})
-      @fabricator.send "create", merge_params(attributes)
+    def create(params = {})
+      @fabricator.send "create", merge_params(params), options
     end
 
-    def search(options = {})
-      @fabricator.send "search", merge_params(options)
+    def search(params = {})
+      @fabricator.send "search", merge_params(params), options
     end
 
-    def fetch(options = nil)
-      @fabricator.send "fetch", merge_params({ id: options })
+    def fetch(params = nil)
+      @fabricator.send "fetch", merge_params({ id: params }), options
     end
 
     private

--- a/lib/iugu/api_create.rb
+++ b/lib/iugu/api_create.rb
@@ -1,11 +1,8 @@
 module Iugu
   module APICreate
     module ClassMethods
-      def create(attributes = {})
-        Iugu::Factory.create_from_response(self.object_type,
-                                           APIRequest.request('POST',
-                                                              self.url(attributes),
-                                                              attributes))
+      def create(attributes = {}, options = {})
+        Iugu::Factory.create_from_response(self.object_type,  APIRequest.request("POST", self.url(attributes), attributes, options), nil, options)
       rescue Iugu::RequestWithErrors => ex
         obj = self.new
         obj.set_attributes attributes, true

--- a/lib/iugu/api_create.rb
+++ b/lib/iugu/api_create.rb
@@ -2,6 +2,7 @@ module Iugu
   module APICreate
     module ClassMethods
       def create(attributes = {}, options = {})
+        options = self.options.merge(options)
         Iugu::Factory.create_from_response(self.object_type,  APIRequest.request("POST", self.url(attributes), attributes, options), nil, options)
       rescue Iugu::RequestWithErrors => ex
         obj = self.new

--- a/lib/iugu/api_create.rb
+++ b/lib/iugu/api_create.rb
@@ -2,7 +2,6 @@ module Iugu
   module APICreate
     module ClassMethods
       def create(attributes = {}, options = {})
-        options = self.options.merge(options)
         Iugu::Factory.create_from_response(self.object_type,  APIRequest.request("POST", self.url(attributes), attributes, options), nil, options)
       rescue Iugu::RequestWithErrors => ex
         obj = self.new

--- a/lib/iugu/api_delete.rb
+++ b/lib/iugu/api_delete.rb
@@ -1,6 +1,7 @@
 module Iugu
   module APIDelete
     def delete(options = {})
+      options = self.options.merge(options)
       APIRequest.request("DELETE", self.class.url(self.attributes), {}, options)
       self.errors = nil
       true

--- a/lib/iugu/api_delete.rb
+++ b/lib/iugu/api_delete.rb
@@ -1,7 +1,7 @@
 module Iugu
   module APIDelete
-    def delete
-      APIRequest.request('DELETE', self.class.url(self.attributes))
+    def delete(options = {})
+      APIRequest.request("DELETE", self.class.url(self.attributes), {}, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/api_fetch.rb
+++ b/lib/iugu/api_fetch.rb
@@ -1,9 +1,7 @@
 module Iugu
   module APIFetch
-    def refresh
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('GET',
-                                                                 self.class.url(self.id)))
+    def refresh(options = {})
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("GET", self.class.url(self.id), {}, options))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -12,10 +10,8 @@ module Iugu
     end
 
     module ClassMethods
-      def fetch(options = nil)
-        Iugu::Factory.create_from_response(self.object_type,
-                                           APIRequest.request('GET',
-                                                              self.url(options)))
+      def fetch(params = nil, options = {})
+        Iugu::Factory.create_from_response(self.object_type, APIRequest.request("GET", self.url(params), {}, options), nil, options)
       end
     end
 

--- a/lib/iugu/api_fetch.rb
+++ b/lib/iugu/api_fetch.rb
@@ -1,6 +1,7 @@
 module Iugu
   module APIFetch
     def refresh(options = {})
+      options = self.options.merge(options)
       copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("GET", self.class.url(self.id), {}, options))
       self.errors = nil
       true

--- a/lib/iugu/api_request.rb
+++ b/lib/iugu/api_request.rb
@@ -4,15 +4,16 @@ require 'json'
 
 module Iugu
   class APIRequest
-
-    def self.request(method, url, data = {})
-      Iugu::Utils.auth_from_env if Iugu.api_key.nil?
-      raise Iugu::AuthenticationException, 'Chave de API não configurada. Utilize Iugu.api_key = ... para configurar.' if Iugu.api_key.nil?
-      handle_response self.send_request method, url, data
+    def self.request(method, url, data = {}, options = {})
+      api_key = options[:api_key] || Iugu.api_key || Iugu::Utils.auth_from_env
+      raise Iugu::AuthenticationException, "Chave de API não configurada. Utilize Iugu.api_key = ... para configurar." if api_key.nil?
+      handle_response self.send_request api_key, method, url, data
     end
 
-    def self.send_request(method, url, data)
-      RestClient::Request.execute build_request(method, url, data)
+    private
+
+    def self.send_request(api_key, method, url, data)
+      RestClient::Request.execute build_request(api_key, method, url, data)
     rescue RestClient::ResourceNotFound
       raise ObjectNotFound
     rescue RestClient::UnprocessableEntity => ex
@@ -21,10 +22,10 @@ module Iugu
       raise RequestWithErrors.new JSON.parse(ex.response)['errors']
     end
 
-    def self.build_request(method, url, data)
+    def self.build_request(api_key, method, url, data)
       {
         verify_ssl: true,
-        headers: default_headers,
+        headers: default_headers(api_key),
         method: method,
         payload: data.to_json,
         url: url,
@@ -41,17 +42,15 @@ module Iugu
       raise RequestFailed
     end
 
-    def self.default_headers
+    def self.default_headers(api_key)
       {
-        authorization: 'Basic ' + Base64.encode64(Iugu.api_key + ':'),
+        authorization: 'Basic ' + Base64.encode64(api_key + ":"),
         accept: 'application/json',
         accept_charset: 'utf-8',
         user_agent: 'Iugu RubyLibrary',
         accept_language: 'pt-br;q=0.9,pt-BR',
-        #content_type: 'application/x-www-form-urlencoded; charset=utf-8'
         content_type: 'application/json; charset=utf-8'
       }
     end
-
   end
 end

--- a/lib/iugu/api_resource.rb
+++ b/lib/iugu/api_resource.rb
@@ -30,7 +30,7 @@ module Iugu
     end
 
     def self.object_base_uri
-      pluralized_models = ["customer", "payment_method", "invoice", "subscription", "plan"]
+      pluralized_models = ["customer", "payment_method", "invoice", "subscription", "plan", "account"]
       if pluralized_models.include? self.object_type
         object_type = self.object_type + "s"
       else

--- a/lib/iugu/api_save.rb
+++ b/lib/iugu/api_save.rb
@@ -1,11 +1,7 @@
 module Iugu
   module APISave
     def save
-      method = is_new? ? 'POST' : 'PUT'
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request(method,
-                                                                 self.class.url(self.attributes),
-                                                                 modified_attributes))
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request(is_new? ? "POST" : "PUT", self.class.url(self.attributes), modified_attributes, options))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/api_save.rb
+++ b/lib/iugu/api_save.rb
@@ -1,7 +1,7 @@
 module Iugu
   module APISave
-    def save
-      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request(is_new? ? "POST" : "PUT", self.class.url(self.attributes), modified_attributes, self.options))
+    def save(options = self.options)
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request(is_new? ? "POST" : "PUT", self.class.url(self.attributes), modified_attributes, options))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/api_save.rb
+++ b/lib/iugu/api_save.rb
@@ -1,7 +1,7 @@
 module Iugu
   module APISave
     def save
-      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request(is_new? ? "POST" : "PUT", self.class.url(self.attributes), modified_attributes, options))
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request(is_new? ? "POST" : "PUT", self.class.url(self.attributes), modified_attributes, self.options))
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/api_search.rb
+++ b/lib/iugu/api_search.rb
@@ -1,8 +1,8 @@
 module Iugu
   module APICreate
     module ClassMethods
-      def search(options = {})
-        Iugu::Factory.create_from_response self.object_type, APIRequest.request("GET", self.url(options), options)
+      def search(params = {}, options = {})
+        Iugu::Factory.create_from_response self.object_type, APIRequest.request("GET", self.url(params), params, options)
       end
     end
 

--- a/lib/iugu/api_search.rb
+++ b/lib/iugu/api_search.rb
@@ -2,6 +2,7 @@ module Iugu
   module APICreate
     module ClassMethods
       def search(params = {}, options = {})
+        options = self.options.merge(options)
         Iugu::Factory.create_from_response self.object_type, APIRequest.request("GET", self.url(params), params, options)
       end
     end

--- a/lib/iugu/charge.rb
+++ b/lib/iugu/charge.rb
@@ -8,7 +8,7 @@ module Iugu
 
     def invoice
       return false unless @attributes['invoice_id']
-      Invoice.fetch @attributes['invoice_id']
+      Invoice.fetch(@attributes['invoice_id'], options)
     end
   end
 end

--- a/lib/iugu/customer.rb
+++ b/lib/iugu/customer.rb
@@ -6,16 +6,16 @@ module Iugu
     include Iugu::APIDelete
 
     def payment_methods
-      APIChildResource.new({ customer_id: self.id }, Iugu::PaymentMethod)
+      APIChildResource.new({ customer_id: self.id }, Iugu::PaymentMethod, options)
     end
 
     def invoices
-      APIChildResource.new({ customer_id: self.id }, Iugu::Invoice)
+      APIChildResource.new({ customer_id: self.id }, Iugu::Invoice, options)
     end
 
     def default_payment_method
       return false unless @attributes['default_payment_method_id']
-      PaymentMethod.fetch({ id: @attributes['default_payment_method_id'], customer_id: self.id })
+      PaymentMethod.fetch({ id: @attributes['default_payment_method_id'], customer_id: self.id }, options)
     end
   end
 end

--- a/lib/iugu/factory.rb
+++ b/lib/iugu/factory.rb
@@ -2,22 +2,19 @@ module Iugu
   class Factory
     def self.create_from_response(object_type, response, errors = nil, options = {})
       if response.nil?
-        obj = Iugu.const_get(Iugu::Utils.camelize(object_type)).new({}, options)
+        obj = Iugu.const_get(Iugu::Utils.camelize(object_type)).new
         obj.errors = errors if errors
         obj.options = options
+
         obj
       elsif response.is_a?(Array)
         results = []
-        response.each do |i|
-          results.push Iugu.const_get(Iugu::Utils.camelize(object_type)).new(i, options)
-        end
-        Iugu::SearchResult.new results, results.count
+        response.each { |i| results.push(Iugu.const_get(Iugu::Utils.camelize(object_type)).new(i, options)) }
+        Iugu::SearchResult.new(results, results.count)
       elsif response['items'] && response['totalItems']
         results = []
-        response['items'].each do |v|
-          results.push self.create_from_response(object_type, v)
-        end
-        Iugu::SearchResult.new results, response['totalItems']
+        response['items'].each { |v| results.push(self.create_from_response(object_type, v, errors, options)) }
+        Iugu::SearchResult.new(results, response['totalItems'])
       else
         Iugu.const_get(Iugu::Utils.camelize(object_type)).new(response, options)
       end

--- a/lib/iugu/factory.rb
+++ b/lib/iugu/factory.rb
@@ -1,14 +1,15 @@
 module Iugu
   class Factory
-    def self.create_from_response(object_type, response, errors = nil)
+    def self.create_from_response(object_type, response, errors = nil, options = {})
       if response.nil?
-        obj = Iugu.const_get(Iugu::Utils.camelize(object_type)).new
+        obj = Iugu.const_get(Iugu::Utils.camelize(object_type)).new({}, options)
         obj.errors = errors if errors
+        obj.options = options
         obj
       elsif response.is_a?(Array)
         results = []
         response.each do |i|
-          results.push Iugu.const_get(Iugu::Utils.camelize(object_type)).new i
+          results.push Iugu.const_get(Iugu::Utils.camelize(object_type)).new(i, options)
         end
         Iugu::SearchResult.new results, results.count
       elsif response['items'] && response['totalItems']
@@ -18,7 +19,7 @@ module Iugu
         end
         Iugu::SearchResult.new results, response['totalItems']
       else
-        Iugu.const_get(Iugu::Utils.camelize(object_type)).new response
+        Iugu.const_get(Iugu::Utils.camelize(object_type)).new(response, options)
       end
     end
   end

--- a/lib/iugu/invoice.rb
+++ b/lib/iugu/invoice.rb
@@ -7,13 +7,11 @@ module Iugu
 
     def customer
       return false unless @attributes['customer_id']
-      Customer.fetch @attributes['customer_id']
+      Customer.fetch(@attributes['customer_id'], options)
     end
 
     def cancel
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/cancel"))
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("PUT", "#{self.class.url(self.id)}/cancel", {}, options), nil, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -22,9 +20,7 @@ module Iugu
     end
 
     def refund
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/refund"))
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("POST", "#{self.class.url(self.id)}/refund", {}, options), nil, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -32,11 +28,10 @@ module Iugu
       false
     end
 
-    def duplicate(attributes = {})
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/duplicate",
-                                                                 attributes ))
+    def duplicate(params = {})
+      params.merge!(id: self.id)
+
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("POST", "#{self.class.url(self.id)}/duplicate", params, options), nil, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex

--- a/lib/iugu/object.rb
+++ b/lib/iugu/object.rb
@@ -3,12 +3,13 @@ require 'set'
 module Iugu
   class Object
 
-    attr_accessor :errors
+    attr_accessor :errors, :options
 
     undef :id if method_defined?(:id)
 
-    def initialize(attributes = {})
+    def initialize(attributes = {}, options = {})
       @unsaved_attributes = Set.new
+      @options = options
       set_attributes attributes
     end
 
@@ -60,6 +61,5 @@ module Iugu
     def metaclass
       class << self; self; end
     end
-
   end
 end

--- a/lib/iugu/plan.rb
+++ b/lib/iugu/plan.rb
@@ -5,10 +5,8 @@ module Iugu
     include Iugu::APISave
     include Iugu::APIDelete
 
-    def self.fetch_by_identifier(identifier)
-      Iugu::Factory.create_from_response(object_type,
-                                         APIRequest.request('GET',
-                                                            "#{url}/identifier/#{identifier}"))
+    def self.fetch_by_identifier(identifier, options = {})
+      Iugu::Factory.create_from_response(object_type, APIRequest.request("GET", "#{url}/identifier/#{identifier}", {}, options), nil, options)
     end
   end
 end

--- a/lib/iugu/subscription.rb
+++ b/lib/iugu/subscription.rb
@@ -6,10 +6,7 @@ module Iugu
     include Iugu::APIDelete
 
     def add_credits(quantity)
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/add_credits",
-                                                                 { quantity: quantity }))
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("PUT", "#{self.class.url(self.id)}/add_credits", { quantity: quantity }, options), nil, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -18,10 +15,7 @@ module Iugu
     end
 
     def remove_credits(quantity)
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('PUT',
-                                                                 "#{self.class.url(self.id)}/remove_credits",
-                                                                 { quantity: quantity }))
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("PUT", "#{self.class.url(self.id)}/remove_credits", { quantity: quantity }, options), nil, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -30,9 +24,7 @@ module Iugu
     end
 
     def suspend
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/suspend"))
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("POST", "#{self.class.url(self.id)}/suspend", {}, options), nil, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -41,9 +33,7 @@ module Iugu
     end
 
     def activate
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/activate"))
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("POST", "#{self.class.url(self.id)}/activate", {}, options), nil, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -51,12 +41,8 @@ module Iugu
       false
     end
 
-    def change_plan(plan_identifier, options = {})
-      options.merge!({ plan_identifier: plan_identifier })
-      copy Iugu::Factory.create_from_response(self.class.object_type,
-                                              APIRequest.request('POST',
-                                                                 "#{self.class.url(self.id)}/change_plan",
-                                                                 options))
+    def change_plan(plan_identifier)
+      copy Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("POST", "#{self.class.url(self.id)}/change_plan/#{plan_identifier}", {}, options), nil, options)
       self.errors = nil
       true
     rescue Iugu::RequestWithErrors => ex
@@ -64,17 +50,13 @@ module Iugu
       false
     end
 
-    def change_plan_simulation(plan_identifier, options = {})
-      options.merge!({ plan_identifier: plan_identifier })
-      Iugu::Factory.create_from_response(self.class.object_type,
-                                         APIRequest.request('GET',
-                                                            "#{self.class.url(self.id)}/change_plan_simulation",
-                                                            options))
+    def change_plan_simulation(plan_identifier)
+      Iugu::Factory.create_from_response(self.class.object_type, APIRequest.request("GET", "#{self.class.url(self.id)}/change_plan_simulation", { plan_identifier: plan_identifier }, options), nil, options)
     end
 
     def customer
       return false unless @attributes['customer_id']
-      Customer.fetch @attributes['customer_id']
+      Customer.fetch @attributes['customer_id'], options
     end
   end
 end


### PR DESCRIPTION
Inspired by the Stripe API, this modification brings the possibility to have a fixed API key through the current implementation Iugu.api_key or send a different api_key as an option on each request, as it follows:

```Iugu::Customer.fetch(api_key: XXX)```